### PR TITLE
Wrap dragula in fastboot guard

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const funnel = require('broccoli-funnel');
 const merge = require('broccoli-merge-trees');
+const map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-cli-dragula-shim',
@@ -23,9 +24,17 @@ module.exports = {
   },
 
   treeForVendor(vendorTree) {
-    const trees = [];
-    const dragulaTree = funnel(path.dirname(require.resolve('dragula/dist/dragula.js')), {
-      files: ['dragula.css', 'dragula.js'],
+    let trees = [];
+
+    let dragulaJsTree = funnel(path.dirname(require.resolve('dragula/dist/dragula.js')), {
+      files: ['dragula.js'],
+      destDir: 'dragula'
+    });
+
+    dragulaJsTree = map(dragulaJsTree, content => `if (typeof FastBoot === 'undefined') { ${content} } else { define(function() { }); }`);
+
+    let dragulaCssTree = funnel(path.dirname(require.resolve('dragula/dist/dragula.js')), {
+      files: ['dragula.css'],
       destDir: 'dragula'
     });
 
@@ -33,7 +42,8 @@ module.exports = {
       trees.push(vendorTree);
     }
 
-    trees.push(dragulaTree);
+    trees.push(dragulaJsTree);
+    trees.push(dragulaCssTree);
 
     return merge(trees);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-dragula-shim",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1474,7 +1474,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
       "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-      "dev": true,
       "requires": {
         "array-equal": "1.0.0",
         "blank-object": "1.0.2",
@@ -1539,7 +1538,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
       "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-      "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
         "merge-trees": "1.0.1"
@@ -1731,7 +1729,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
       "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
-      "dev": true,
       "requires": {
         "broccoli-debug": "0.6.4",
         "broccoli-funnel": "1.2.0",
@@ -1753,7 +1750,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
           "requires": {
             "array-equal": "1.0.0",
             "blank-object": "1.0.2",
@@ -1775,7 +1771,6 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "1.3.0",
             "can-symlink": "1.0.0",
@@ -1791,7 +1786,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0"
@@ -5455,8 +5449,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -6051,7 +6044,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -6745,7 +6737,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-      "dev": true,
       "requires": {
         "can-symlink": "1.0.0",
         "fs-tree-diff": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "dragula": "smashweaver/dragula.git#mousemove",
     "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-funnel": "^2.0.1",
-    "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",


### PR DESCRIPTION
Dragula.js has a reference to `document`, which will error inside of an Ember application using fastboot.

This PR adds the fix from [this guide](https://github.com/ember-fastboot/ember-cli-fastboot#appimport-in-the-applications-ember-cli-buildjs), which recommends wrapping the module in an if statement so it will only eval in non fastboot environments. 

I also moved funnel and merge-trees to dependencies, since these are using inside of the addon's index.js.